### PR TITLE
Improve CSS for smaller screens

### DIFF
--- a/css/templatemo_style.css
+++ b/css/templatemo_style.css
@@ -241,13 +241,25 @@ p {
 }
 
 .banner-content h2 {
-  font-size: 80px;
+  font-size: 35px;
   font-weight: 700;
   text-transform: uppercase;
   color: #fff;
   letter-spacing: 2px;
   margin-top: 0px;
   margin-bottom: 30px;
+}
+
+@media (min-width: 370px) {
+    .banner-content h2 {
+      font-size: 40px;
+    }
+}
+
+@media (min-width: 768px) {
+    .banner-content h2 {
+      font-size: 80px;
+    }
 }
 
 .banner-content h3 {

--- a/index.html
+++ b/index.html
@@ -226,11 +226,6 @@ http://www.templatemo.com/tm-508-power
                                 <a href="https://www.techatbloomberg.com/" title="Bloomberg"><img src="img/bloomberg.png" alt="Bloomberg" /></a>
                             </div>
                         </div>
-                        <div class="item">
-                            <div class="sponsors-item">
-                                <a href="https://www.techatbloomberg.com/" title="Codethink"><img src="img/codethink.png" alt="Codethink" /></a>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The "PYLONDINIUM18" header was making the page really wide. This patch makes this text smaller in smaller screens.

Also remove Codethink sponsor, given that is not confirmed yet.