### PR TITLE
Add UK to make clear the conference is in London

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ http://www.templatemo.com/tm-508-power
                 <div class="row">
                     <div class="col-md-12">
                         <h4>A Python conference for developers and users of Python</h4>
-                        <h6>In the heart of the City of London</h6>
+                        <h6>In the heart of the City of London, UK</h6>
                         <div class="border-button"><a href="#about">Discover More</a></div>
                     </div>
                 </div>


### PR DESCRIPTION
We got some questions from users asking if the conference was in Canada, there is indeed not a lot of information about the country other than the venue.