### PR TITLE
Add ticketea widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,17 @@ http://www.templatemo.com/tm-508-power
             </div>
         </div>
 
+        <div class="tickets">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="section-heading">
+            <div id="tkt-content">Buy your tickets here</div><script language="javascript" type="text/javascript" src="https://www.ticketea.co.uk/tickets-conference-pylondinium18/buy?width=600px&height=600px"></script><a href="//www.ticketea.co.uk/tickets-conference-pylondinium18/" alt="PyLondinium18" title="ticketea"><img src="https://www.ticketea.co.uk/images/powered_by.png" alt="ticketea" /></a>
+                        </div>
+                    </div>
+                </div>
+			</div>
+		</div>
 
         <div class="intro">
             <div class="container">


### PR DESCRIPTION
Some speakers have raised up that it is not easy to spot how to buy tickets for Pylondinium. This adds the widget form ticketea that will be visible on opening the page. We can remove it once the sale closes.

Preview: https://mariocj89.github.io/pylondinium/