### PR TITLE
Tweak colour scheme on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,12 +37,12 @@
           and talks. We'll be returning to Bloomberg's European HQ in the heart of the City of
           London, June 14th, 15th, and 16th, 2019.
         </p>
-        <div class="row" style="margin: 1em; padding: 2em; border-radius: 1em; background: #ff5c5c;">
-          <div class="col-sm">
-            <a href="https://www.papercall.io/pylondinium-2019" class="btn btn-lg btn-success">Call For Papers</a>
+        <div class="row">
+          <div class="col-sm" style="margin-top: 1em; margin-bottom: 1em;">
+            <a href="https://www.papercall.io/pylondinium-2019" class="btn btn-lg btn-secondary" style="background: #D95656; border-color: #FFDDCC">Call For Papers</a>
           </div>
-          <div class="col-sm">
-            <a href="http://eepurl.com/ga6KzH" class="btn btn-lg btn-secondary">Keep up to date</a>
+          <div class="col-sm" style="margin-top: 1em; margin-bottom: 1em;">
+            <a href="http://eepurl.com/ga6KzH" class="btn btn-lg btn-secondary" style="background: #D95656; border-color: #FFDDCC">Keep up to date</a>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Tweak the colours of the the CfP and mailing list buttons to fit the overall colour scheme better. I think the green button was very out of place so I tried to improve it a bit. I know this is very subjective, so feel free to reject it.

The palette was generated based on the picture of the landing page:
https://coolors.co/ffddcc-c1aaaa-a7968d-a94d4d-d95656.

Sample:
<img width="862" alt="Screenshot 2019-03-21 at 21 46 46" src="https://user-images.githubusercontent.com/791741/54787218-f2588f80-4c22-11e9-93c5-ffcc83011b96.png">
