### PR TITLE
"pandas ecosystem 2019" talk updated

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -227,7 +227,7 @@
             </tr>
             <tr>
                 <th scope="row" class="text-right">15:00</th>
-                <td><a href="https://pylondinium.org/talks/talk-24.html">pandas ecosystem 2019</a><br />
+                <td><a href="https://pylondinium.org/talks/talk-24.html">Breaking pandas</a><br />
 <i>Marc Garcia</i></td>
                 <td><a href="https://pylondinium.org/talks/talk-25.html">Localisation Infrastructure in Yelp</a><br />
 <i>Sherry Wang</i></td>

--- a/talks.json
+++ b/talks.json
@@ -168,9 +168,9 @@
         "bio": "Marco Bonzanini is a freelance Data Scientist based in London, UK. Co-organiser of the PyData London meet-up and co-chair of the PyData London 2018-19 conference. Python publications: Mastering Social Media Mining with Python (book, PacktPub, 2016) Data Analysis with Python (video course, PacktPub, 2017) Practical Python Data Science Techniques (video course, PacktPub, 2017)"
     },
     {
-        "title": "pandas ecosystem 2019",
+        "title": "Breaking pandas",
         "name": "Marc Garcia",
-        "abstract": "pandas is becoming a de-facto standard for data manipulation and analysis in Python. But it's not alone, many other projects are being developed to help in this task. In this talk pandas and its ecosystem will be presented.",
+        "abstract": "pandas is becoming a de-facto standard for data manipulation and analysis in Python. But it's not alone, many other projects are being developed to help in this task. In this talk I will present some ideas on how to break pandas to have a healthier ecosystem.",
         "description": "pandas is more than 10 years old now. In this time, it became almost a standard for building data pipelines and perform data analysis in Python. As the popularity of the project grows, it also grows the number of projects that depend or interact with pandas.\r\n\r\nThis talk will cover this ecosystem of projects around pandas, mainly in the prespective of scalability and performance. Discussing for example how projects like Arrow are key for the future of pandas, or how Dask is overcoming pandas limitations.\r\n\r\nIn a first part, the talk will focus on pandas itself, its components, and its architecture. This will give the required context for a second part, that will explain related projects, how they interact with pandas, and what the whole ecosystem can offer to users.",
         "bio": "Marc Garcia is a pandas core developer and Python fellow.\r\n\r\nHe has been working in Python for more than 12 years, and worked as data scientist and data engineer for different companies such as Bank of America, Tesco and Badoo.\r\nHe is a regular speaker at PyData and PyCon conferences, and a regular organizer of sprints."
     },

--- a/talks/talk-24.html
+++ b/talks/talk-24.html
@@ -39,14 +39,14 @@
         
 <div class="row">
   <div class="col">
-    <h1 class="red-text">pandas ecosystem 2019</h1>
+    <h1 class="red-text">Breaking pandas</h1>
     <h2 class="red-text">Marc Garcia</h2>
   </div>
 </div>
 <div class="row">
   <div class="col talk" style="text-align: justify">
     <h2 style="text-align: center">Abstract</h2>
-    <p>pandas is becoming a de-facto standard for data manipulation and analysis in Python. But it's not alone, many other projects are being developed to help in this task. In this talk pandas and its ecosystem will be presented.</p>
+    <p>pandas is becoming a de-facto standard for data manipulation and analysis in Python. But it's not alone, many other projects are being developed to help in this task. In this talk I will present some ideas on how to break pandas to have a healthier ecosystem.</p>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
While the content will be exactly the same, I'll be making my talk a bit more a story, based on feedback from PyConX (where it was also delivered). Because of this, the title "Breaking pandas" will be a bit more appropriate (and hopefully cooler) than "pandas ecosystem 2019". Updating the program with the proposed change.