### PR TITLE
Linkify Python Code Dojo in schedule

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -53,7 +53,11 @@
                 <th>Full Day</th>
                 <td><a href="https://girls.pylondinium.org/">PyLondinium Girls</a></td>
                 <td><a href="https://pylondinium.org/talks/transcode.html">Trans*Code</a></td>
-                <td>Python Dojo</td>
+            </tr>
+            <tr>
+                <th>Afternoon Only</th>
+                <td><a href="https://go.bloomberg.com/attend/invite/workshop-python-dojo/">Python Code Dojo</a></td>
+                <td>&nbsp;</td>
             </tr>
         </table>
     </div>

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -20,7 +20,11 @@
                 <th>Full Day</th>
                 <td><a href="https://girls.pylondinium.org/">PyLondinium Girls</a></td>
                 <td><a href="{{base}}talks/transcode.html">Trans*Code</a></td>
-                <td>Python Dojo</td>
+            </tr>
+            <tr>
+                <th>Afternoon Only</th>
+                <td><a href="https://go.bloomberg.com/attend/invite/workshop-python-dojo/">Python Code Dojo</a></td>
+                <td>&nbsp;</td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
Now that we have the [Python Code Dojo signup page](https://go.bloomberg.com/attend/invite/workshop-python-dojo/), this links to it from the schedule page.

This comes out as:
![image](https://user-images.githubusercontent.com/167319/58438834-dcef5e00-80c8-11e9-9312-23599a5cefa6.png)
