### PR TITLE
make CFP close time match www.papercall.io/pylondinium-2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <p style="text-align: left; margin: 2em" class="copy">
       The <a href="https://www.papercall.io/pylondinium-2020">Call for Proposals</a>
       is now open! Whether you're a first time presenter or you've keynoted PyCon,
-      we're looking for a proposal from you. The CfP will close at March 26, 2020 00:00 UTC and you can find all the details you need on <a href="https://www.papercall.io/pylondinium-2020">PaperCall</a>.
+      we're looking for a proposal from you. The CfP will close at March 25, 2020 23:59 UTC and you can find all the details you need on <a href="https://www.papercall.io/pylondinium-2020">PaperCall</a>.
     </p>
 </div>
 


### PR DESCRIPTION
As discussed with Dobromir Tochilarov; CFP closes at 23:59 to avoid date confusion.